### PR TITLE
Also download files with jpeg extension

### DIFF
--- a/download-photos.ts
+++ b/download-photos.ts
@@ -80,7 +80,7 @@ async function scrapePostForImages(page: puppeteer.Page, link: SocialSchoolsLink
   }
 
   // Find & click on first image preview
-  const imagePreview = await findAccessibilityTreeNode(snapshot, (n) => n.role === 'button' && !!n.name?.match(/\.(jpg|png|mp4|mov)/));
+  const imagePreview = await findAccessibilityTreeNode(snapshot, (n) => n.role === 'button' && !!n.name?.match(/\.(jpeg|jpg|png|mp4|mov)/));
   if (!imagePreview) {
     console.warn("No images found in the post.");
     return;


### PR DESCRIPTION
Thank you for this wonderful tool @FooBarWidget ! I had till today to download photographs, and I wouldn't have made that deadline without your tool.

And thanks for the crash-course in typescript and puppeteer it enabled. I'll give you one or two other Pull Requests with the changes I needed to make.

But first a simple one, I noticed that my school sometimes uses `.jpeg` as a file extension, and other schools might as well, so that should be included.