### PR TITLE
Continue even if it is uncertain whether the post is loaded

### DIFF
--- a/download-photos.ts
+++ b/download-photos.ts
@@ -70,7 +70,12 @@ async function scrapePostForImages(page: puppeteer.Page, link: SocialSchoolsLink
   // Load post
   console.log('Waiting for post to load...');
   await page.goto(link.href, { waitUntil: "domcontentloaded", timeout: 10000 });
-  await page.waitForSelector('main .ss-chat', { timeout: 10000 });
+  try {
+    await page.waitForSelector('main .ss-chat', { timeout: 5000 });
+  } catch (e) {
+    console.log('Timeout detecting the images; continuing anyway.')
+    // Just continue because posts with images might have the chat function disabled.
+  }
   console.log('Post loaded');
 
   // Get accessibility tree


### PR DESCRIPTION
It seems that 99c3e5feef0330af89fdad340338a561ea8fff5a was not entirely successful in detecting posts with images.

My school had some posts with images where the chat function was disabled, and those posts were discarded.

As a safety net, this PR just continues with parsing the post even if it is uncertain whether there are images.