### PR TITLE
Parse links from the home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Automates downloading photos from Social Schools.
 ## Setup
 
 - `npm install`
-- Create an OAuth consent screen in Google Cloud for the Gmail domain. Download the client credentials JSON file and store it in `google_oauth_client_credentials.json`.
+- (Optionally) create an OAuth consent screen in Google Cloud for the Gmail domain. Download the client credentials JSON file and store it in `google_oauth_client_credentials.json`.
 
 ## Run
 
-1. `npx tsx extract-links.ts` to fetch Social Schools email from Gmail inbox. Extracts all Social Schools post links to links.json.
+1. (Optionally) `npx tsx extract-links.ts` to fetch Social Schools email from Gmail inbox. Extracts all Social Schools post links to links.json.
 2. `npx tsx download-photos.ts` to download photos.
    - In the automated browser, make sure to login manually.
    - Photos are downloaded to `downloaded_photos/`, grouped by date and post subject.

--- a/download-photos.ts
+++ b/download-photos.ts
@@ -13,14 +13,6 @@ interface SocialSchoolsLinkWithMediaSources extends SocialSchoolsLink {
 }
 
 async function main() {
-  if (!(await pathExists("links.json"))) {
-    console.error(
-      `Error: Links file not found at links.json. Please run 'npx tsx extract-links.ts' first.`
-    );
-    process.exit(1);
-  }
-
-  const links = loadLinks();
   const browser = await puppeteer.launch({ headless: false });
   let exitStatus = 0;
 
@@ -29,11 +21,17 @@ async function main() {
       const page = await browser.newPage();
       await loginSocialSchools(page);
 
-      for (const link of links) {
-        await scrapePostForImages(page, link);
+      if (!(await pathExists("links.json"))) {
+        console.log(
+            `Links file not found at links.json. Retrieving links from home page. Or run 'npx tsx extract-links.ts' first.`
+        );
+        await fetchLinksFromHome(page);
       }
 
+      const links = loadLinks();
+
       for (const link of links) {
+        await scrapePostForImages(page, link);
         await downloadImages(page, link);
       }
     } catch (err: any) {
@@ -62,6 +60,115 @@ async function loginSocialSchools(page: puppeteer.Page) {
   await page.goto('https://app.socialschools.eu');
   await page.locator('::-p-text(Agenda voor de komende)').wait();
   console.log("Logged in to Social Schools.");
+}
+
+async function fetchLinksFromHome(page: puppeteer.Page) {
+  // Fetch the links to the posts from the Social Schools home page.
+
+  // The home page only shows a handful of posts. Scrolling down
+  // will load more posts (with a rotating spinner and all).
+  // The actual end of the page will have the text
+  // "Er zijn niet meer berichten" in this div:
+  // <div role="alert" class="fade alert alert-muted show"><span>Er zijn niet meer berichten</span></div>
+  // This is the only diff with the class 'fade'.
+  // So it is necessary to scroll until that diff is found.
+
+  // Scrolling to the end can take minutes, so set the timeout to 10 minutes.
+  // Set the timeout lower for debugging.
+  // let timeout = 600000;
+  let timeout = 10000;
+  const startTime = Date.now();
+
+  while (true) {
+    // Check if the element is already present
+    const isFadeVisible = await page.$('.fade') !== null;
+    if (isFadeVisible) {
+      console.log('Element with class "fade" found.');
+      break;
+    }
+    console.log('Element with class "fade" not found, scrolling down.');
+
+    // Scroll down a bit
+    await page.evaluate(() => {
+      console.log('Window height:', window.innerHeight);
+      window.scrollBy(0, window.innerHeight);
+      console.log('Window height:', window.innerHeight);
+    });
+
+    // Wait a bit to allow content to load.
+    await new Promise(resolve => setTimeout(resolve, 300));
+
+    // Check for timeout.
+    if (Date.now() - startTime > timeout) {
+      console.log('Timeout: Element with class "fade" not found after scrolling.');
+      // Just continue with what is already available.
+      break;
+    }
+
+  }
+
+  // Get all the posts.
+  // Not sure how to filter out the ones with images from this view.
+  const posts = await page.$$eval('div[role="article"][id^="post_"]', (postDivs) => {
+
+    // Don't know how to abstract this logic away in a function.
+    // That gives this error:
+    // Error [ReferenceError]: __name is not defined
+    return postDivs.map(post => {
+      // Written by the toaster.
+      // Extract post ID
+      const idAttr = post.getAttribute('id');
+      const postId = idAttr?.replace('post_', '') ?? null;
+
+      // Extract title from <h3>
+      const titleEl = post.querySelector('h3 span.user-text span');
+      const title = titleEl?.textContent?.trim() ?? null;
+
+      // Extract raw date string
+      const dateAnchor = post.querySelector('a.meta-info span span');
+      const rawDate = dateAnchor?.textContent?.trim() ?? null;
+
+      return { postId, rawDate, title };
+    });
+  });
+
+  console.log(posts);
+
+  // Parse date to standard ISO format
+  // Written by the toaster.
+  const parsedPosts: SocialSchoolsLink[] = posts.map(({ postId, rawDate, title }) => {
+    let parsedDate: Date | null = null;
+
+    if (rawDate) {
+      const match = rawDate.match(/^(\d{1,2}) (\w+)(?: om (\d{1,2}:\d{2}))?/);
+      if (match) {
+        const [_, day, monthDutch, time = '00:00'] = match;
+        const monthMap: Record<string, string> = {
+          januari: '01', februari: '02', maart: '03', april: '04',
+          mei: '05', juni: '06', juli: '07', augustus: '08',
+          september: '09', oktober: '10', november: '11', december: '12',
+        };
+        const month = monthMap[monthDutch.toLowerCase()];
+        if (month) {
+          const year = new Date().getFullYear();
+          const isoString = `${year}-${month}-${day.padStart(2, '0')}T${time}:00`;
+          parsedDate = new Date(isoString);
+        }
+      }
+    }
+
+    return {
+      messageId: postId ?? '',
+      date: parsedDate ?? new Date(0),
+      subject: title ?? undefined,
+      href: `https://app.socialschools.eu/communityposts/${postId}`,
+    };
+  });
+
+  console.log(parsedPosts);
+
+  fs.writeFileSync('links.json', JSON.stringify(parsedPosts, null, 2));
+  console.log(`${parsedPosts.length} links extracted and saved to links.json`);
 }
 
 async function scrapePostForImages(page: puppeteer.Page, link: SocialSchoolsLinkWithMediaSources) {


### PR DESCRIPTION
Automatically fetch the links to the posts from the home page if no links.json is specified.

I couldn't get the GMail OAuth functionality to work. So I decided to learn some typescript and puppeteering and made `download-photos.ts` fetch the links to the posts from the homepage directly.

I used a toaster (ChatGPT) to help me, and while it works, I'm not convinced the code is idiomatic, so I would appreciate if you could tell me whether I did something stupid @FooBarWidget .

In particular the `$$eval` bit (where the title and date of the post is part) looks weird to me. It looks like I might be mixing two different paradigms or something like that.

The date-parsing code is entirely ChatGPT too; it works. Didn't even look at it until now, and I can't imaging this is how one is supposed to deal with dates.

The exercise was kinda interesting; LLM's are apparently quite a good (or at least effective) tool for such problems. I can share the chat privately if you'd be interested.